### PR TITLE
fix: remove cython type for MAX_SIZE

### DIFF
--- a/src/chacha20poly1305_reuseable/__init__.pxd
+++ b/src/chacha20poly1305_reuseable/__init__.pxd
@@ -30,7 +30,7 @@ cdef object ffi_new
 cdef object ffi_from_buffer
 cdef object ffi_buffer
 
-cdef cython.long MAX_SIZE
+cdef object MAX_SIZE
 cdef cython.uint KEY_LEN
 cdef object NONCE_LEN
 cdef cython.uint NONCE_LEN_UINT


### PR DESCRIPTION
While it works fine and tests fine, This seems to have a comparison problem on some 32-bit platforms:
https://github.com/home-assistant/core/issues/102474 https://github.com/home-assistant/core/issues/102473